### PR TITLE
Change webpack config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,9 @@ Below is the relevant snipet from a `webpack.config.js` with `dev: true` set.
         use: {
           loader: 'svelte-loader',
           options: {
-            dev: true,
+            compilerOptions: {
+              dev: true,
+            }
           },
         },
       },


### PR DESCRIPTION
In order for the extension to work with svelte-loader > 3  with webpack I had to change config to

Change webpack config to:

```js
options: {
  compilerOptions: {
    dev: true,
  },
},
```

Don't know if there are unexpected side effects though.