### PR TITLE
Automatically build icons for packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "build:chrome": "cross-env TARGET=chrome rollup -c",
     "build:icon": "node ./scripts/buildIcons.mjs",
     "dev": "http-serve test/public -p 8940 & web-ext run -s dest -u http://127.0.0.1:8940 -u about:debugging && kill $!",
-    "package:firefox": "yarpm run build:firefox && web-ext build -s dest",
-    "package:chrome": "yarpm run build:chrome && web-ext build -s dest"
+    "package:firefox": "yarpm run build:icon && yarpm run build:firefox && web-ext build -s dest",
+    "package:chrome": "yarpm run build:icon && yarpm run build:chrome && web-ext build -s dest"
   },
   "devDependencies": {
     "cross-env": "^7.0.3",


### PR DESCRIPTION
This fixes browsers failing to load built extensions without icons. Alternatively, you could just add `yarpm run build:icon` to README.