### PR TITLE
Enable Dependabot integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  


### PR DESCRIPTION
This config file enables [Dependabot](https://dependabot.com/) integration. Dependabot is provided by GitHub for free.

After this file is merged, Dependabot will check for `npm` module updates and create PRs to bump outdated modules. These PRs will automatically trigger all the CI workflows. If you have never used Dependabot, I can answer questions about it. I use Dependabot on most of my projects and it is pretty handy.

## Motivation
Updating dependencies is a chore which can be uatomated with Dependabot.

`npm audit` produces the following report:

```
# npm audit report

minimist  <0.2.1 || >=1.0.0 <1.2.3
Prototype Pollution - https://npmjs.com/advisories/1179
No fix available
node_modules/optimist/node_modules/minimist
  optimist  >=0.6.0
  Depends on vulnerable versions of minimist
  node_modules/optimist
    http-serve  *
    Depends on vulnerable versions of optimist
    node_modules/http-serve

postcss  7.0.0 - 8.2.9
Severity: moderate
Regular Expression Denial of Service - https://npmjs.com/advisories/1693
fix available via `npm audit fix --force`
Will install web-ext@6.1.0, which is a breaking change
node_modules/addons-linter/node_modules/postcss
  addons-linter  1.3.5 - 3.1.0
  Depends on vulnerable versions of postcss
  node_modules/addons-linter
    web-ext  2.9.2 - 6.0.0
    Depends on vulnerable versions of addons-linter
    node_modules/web-ext

qs  <=6.0.3 || 6.1.0 - 6.1.1 || 6.2.0 - 6.2.2 || 6.3.0 - 6.3.1
Severity: high
Prototype Pollution Protection Bypass - https://npmjs.com/advisories/1469
fix available via `npm audit fix`
node_modules/qs
  union  0.1.2 - 0.4.6
  Depends on vulnerable versions of qs
  node_modules/union

8 vulnerabilities (3 low, 3 moderate, 2 high)
```