### PR TITLE
Add ESLint (based on Standard)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "env": {
+    "browser": true,
+    "commonjs": true,
+    "es6": true,
+    "node": true,
+    "jasmine": true,
+    "webextensions": true
+  },
+  "extends": [
+    "standard"
+  ],
+  "globals": {
+    "Atomics": "readonly",
+    "SharedArrayBuffer": "readonly"
+  },
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2018
+  },
+  "plugins": ["@typescript-eslint"],
+  "rules": {
+    "eqeqeq": "warn",
+    "space-before-function-paren": "warn",
+    "comma-dangle": "warn",
+    "no-case-declarations": "warn",
+    "no-duplicate-case": "warn",
+    "curly": "warn",
+    "operator-linebreak": "warn",
+    "prefer-const": "warn",
+    "indent": "warn",
+    "no-new": "warn",
+    "no-unused-vars": "warn",
+    "no-sequences": "warn"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,10 +10,17 @@
     "build:icon": "node ./scripts/buildIcons.mjs",
     "dev": "http-serve test/public -p 8940 & web-ext run -s dest -u http://127.0.0.1:8940 -u about:debugging && kill $!",
     "package:firefox": "yarpm run build:icon && yarpm run build:firefox && web-ext build -s dest",
-    "package:chrome": "yarpm run build:icon && yarpm run build:chrome && web-ext build -s dest"
+    "package:chrome": "yarpm run build:icon && yarpm run build:chrome && web-ext build -s dest",
+    "test:lint": "eslint src/ --ext ts --ext js"
   },
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^4.26.0",
+    "@typescript-eslint/parser": "^4.26.0",
     "cross-env": "^7.0.3",
+    "eslint": "^7.27.0",
+    "eslint-config-standard": "^16.0.3",
+    "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-standard": "^5.0.0",
     "http-serve": "^1.0.1",
     "postcss": "^8.2.2",
     "postcss-sorting": "^6.0.0",

--- a/src/background.js
+++ b/src/background.js
@@ -45,12 +45,12 @@ function handlePageMessage(msg, port) {
 
 function attachScript(tabId, changed) {
   if (
-    !toolsPorts.has(tabId) ||
-    changed.status != 'loading' ||
+    !toolsPorts.has(tabId)
+    || changed.status != 'loading'
     // #if process.env.TARGET === 'firefox'
-    !changed.url
+    || !changed.url
     // #else
-    false
+    || false
     // #endif
   )
     return


### PR DESCRIPTION
# Motivation

ESLint helps keep code neet (formatted nicely) and can perform some basic static analysis checks which might prevent run-time errors. Ideally, this will be integrated with GitHub Actions CI.

# Example run
All rules are set to `"warn"` to minimize the diff LoC count.

```
$ npm run test:lint

> svelte-devtools@1.3.0 test:lint
> eslint src/ --ext ts --ext js


C:\svelte-devtools\src\background.js
   5:23  warning  Expected '===' and instead saw '=='           eqeqeq
  16:28  warning  Missing space before function parentheses     space-before-function-paren
  25:7   warning  Unexpected lexical declaration in case block  no-case-declarations
  34:5   warning  Duplicate case label                          no-duplicate-case
  35:7   warning  Unexpected lexical declaration in case block  no-case-declarations
  36:13  warning  Expected '!==' and instead saw '!='           eqeqeq
  41:27  warning  Missing space before function parentheses     space-before-function-paren
  46:22  warning  Missing space before function parentheses     space-before-function-paren
  47:3   warning  Expected { after 'if' condition               curly
  49:5   warning  '||' should be placed at the end of the line  operator-linebreak
  49:23  warning  Expected '!==' and instead saw '!='           eqeqeq
  51:5   warning  '||' should be placed at the end of the line  operator-linebreak
  53:5   warning  '||' should be placed at the end of the line  operator-linebreak
  60:28  warning  Unexpected trailing comma                     comma-dangle
  64:28  warning  Unexpected trailing comma                     comma-dangle
  68:15  warning  Missing space before function parentheses     space-before-function-paren
  74:11  warning  Expected '!==' and instead saw '!='           eqeqeq

C:\svelte-devtools\src\client\highlight.js
   36:19  warning  Missing space before function parentheses  space-before-function-paren
   76:25  warning  Missing space before function parentheses  space-before-function-paren
   77:17  warning  Expected '===' and instead saw '=='        eqeqeq
  100:26  warning  Missing space before function parentheses  space-before-function-paren
  131:25  warning  Missing space before function parentheses  space-before-function-paren
  136:21  warning  Missing space before function parentheses  space-before-function-paren
  141:27  warning  Missing space before function parentheses  space-before-function-paren
  146:28  warning  Missing space before function parentheses  space-before-function-paren

C:\svelte-devtools\src\client\index.js
   10:49  warning  Missing space before function parentheses             space-before-function-paren
   11:7   warning  'component' is never reassigned. Use 'const' instead  prefer-const
   15:51  warning  Missing space before function parentheses             space-before-function-paren
   16:7   warning  'node' is never reassigned. Use 'const' instead       prefer-const
   22:23  warning  Missing space before function parentheses             space-before-function-paren
   52:15  warning  Missing space before function parentheses             space-before-function-paren
   63:7   warning  Unexpected lexical declaration in case block          no-case-declarations
   76:13  warning  Missing space before function parentheses             space-before-function-paren
   82:17  warning  Expected '===' and instead saw '=='                   eqeqeq
   83:42  warning  Expected '===' and instead saw '=='                   eqeqeq
   88:26  warning  Missing space before function parentheses             space-before-function-paren
   94:23  warning  Missing space before function parentheses             space-before-function-paren
  141:1   warning  Expected indentation of 12 spaces but found 14        indent
  142:1   warning  Expected indentation of 12 spaces but found 14        indent
  143:1   warning  Expected indentation of 10 spaces but found 12        indent
  174:6   warning  Missing space before function parentheses             space-before-function-paren
  183:9   warning  Missing space before function parentheses             space-before-function-paren
  190:9   warning  Missing space before function parentheses             space-before-function-paren
  197:10  warning  Missing space before function parentheses             space-before-function-paren

C:\svelte-devtools\src\index.js
   5:21  warning  Missing space before function parentheses  space-before-function-paren
   6:13  warning  Expected '===' and instead saw '=='        eqeqeq
  11:1   warning  Expected { after 'if' condition            curly
  14:1   warning  Do not use 'new' for side effects          no-new

C:\svelte-devtools\src\store.js
    1:25  warning  'derived' is defined but never used              no-unused-vars
   10:16  warning  Unexpected trailing comma                        comma-dangle
   41:27  warning  Missing space before function parentheses        space-before-function-paren
   68:11  warning  Unexpected var, use let or const instead         no-var
   69:11  warning  Unexpected var, use let or const instead         no-var
  112:47  warning  Unexpected trailing comma                        comma-dangle
  115:23  warning  Missing space before function parentheses        space-before-function-paren
  118:49  warning  Unexpected trailing comma                        comma-dangle
  122:28  warning  Missing space before function parentheses        space-before-function-paren
  125:49  warning  Unexpected trailing comma                        comma-dangle
  129:27  warning  Missing space before function parentheses        space-before-function-paren
  132:49  warning  Unexpected trailing comma                        comma-dangle
  140:20  warning  Unexpected trailing comma                        comma-dangle
  159:11  warning  Unexpected trailing comma                        comma-dangle
  166:49  warning  Unexpected trailing comma                        comma-dangle
  170:14  warning  Missing space before function parentheses        space-before-function-paren
  172:20  warning  Missing space before function parentheses        space-before-function-paren
  176:61  warning  Expected '===' and instead saw '=='              eqeqeq
  178:13  warning  Expected '!==' and instead saw '!='              eqeqeq
  187:22  warning  Missing space before function parentheses        space-before-function-paren
  194:20  warning  Unexpected trailing comma                        comma-dangle
  198:28  warning  Missing space before function parentheses        space-before-function-paren
  206:56  warning  Expected '===' and instead saw '=='              eqeqeq
  211:58  warning  Expected '===' and instead saw '=='              eqeqeq
  219:25  warning  Expected '===' and instead saw '=='              eqeqeq
  256:49  warning  Unexpected use of comma operator                 no-sequences
  268:62  warning  Expected '===' and instead saw '=='              eqeqeq
  282:35  warning  Expected '===' and instead saw '=='              eqeqeq
  290:11  warning  'node' is never reassigned. Use 'const' instead  prefer-const

✖ 77 problems (0 errors, 77 warnings)
  0 errors and 56 warnings potentially fixable with the `--fix` option.
```