### PR TITLE
Ignore web-ext-artifacts/ folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ credentials
 test/public/bundle.js
 test/public/styles.css
 test/public/styles.css.map
+web-ext-artifacts/


### PR DESCRIPTION
web-ext-artifacts/ contains output files generated by package scripts,
it should not be included in git.