### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# This file specifies formatting convention for the source code
+# Learn more at: https://EditorConfig.org
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+
+# Indent JavaScript and TypeScript files with two spaces
+[*.{js,ts}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
This file specifies formatting configuration for text editors so that, e.g., VisualStudio (Code) does not mess up formatting of text files, creating large commit diffs. This configuation can be extended later (e.g., to include Svelte and other files), but now it fixes all JS and TS files for me. If you have never used EditorConfig, I can answer your questions.