### PR TITLE
Declare ES5 strict mode for background script

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,3 +1,5 @@
+'use strict'
+
 const toolsPorts = new Map()
 
 chrome.runtime.onConnect.addListener(port => {


### PR DESCRIPTION
Enabling ES5 strict mode for background script can help avoid
bugs which could surface after switch from background (event) pages to
background service workers (which require strict mode). Right now, this
change has no effect because background script is already ES5 strict
mode compliant.