### PR TITLE
Use `chrome.devtools.network.onNavigated`

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -85,7 +85,6 @@ export default [{
     e => e.source == window && sendMessage(e.data),
     false
   )
-  window.addEventListener('unload', () => sendMessage({ type: 'clear' }))
 }`
   },
   plugins: [ resolve() ]

--- a/src/store.js
+++ b/src/store.js
@@ -227,16 +227,15 @@ function resolveEventBubble(node) {
   }
 }
 
+/* When page is reloaded or refreshed we need to 'clear' past data */
+chrome.devtools.network.onNavigated.addListener(() => {
+  selectedNode.set({})
+  hoveredNodeId.set(null)
+  rootNodes.set([])
+})
+
 port.onMessage.addListener(msg => {
   switch (msg.type) {
-    case 'clear': {
-      selectedNode.set({})
-      hoveredNodeId.set(null)
-      rootNodes.set([])
-
-      break
-    }
-
     case 'addNode': {
       const node = msg.node
       node.children = []


### PR DESCRIPTION
Use chrome.devtools.network.onNavigated instead of page context
unload event.

This acheives the same result and has several advantages:
 - `unload` listeners can be unreliable with async operations (the context might be unloaded before message is sent)
 - `unload` listeners can interfere with [bfcache](https://web.dev/bfcache/#never-use-the-unload-event) (especially on Firefox)
 - (subjectively) nicer-looking code