### PR TITLE
Avoid excessive chrome.tabs.onUpdated invocations

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -86,6 +86,7 @@ export default [{
     false
   )
   window.addEventListener('unload', () => sendMessage({ type: 'clear' }))
+  sendMessage({ type: 'ready' })
 }`
   },
   plugins: [ resolve() ]

--- a/src/store.js
+++ b/src/store.js
@@ -227,6 +227,19 @@ function resolveEventBubble(node) {
   }
 }
 
+/*
+ * When page is reloaded or refreshed we need to notify background
+ * so it injects content script.
+ */
+// #if process.env.TARGET !== 'firefox'
+chrome.devtools.network.onNavigated.addListener(() => {
+  port.postMessage({
+    type: 'navigation',
+    tabId: chrome.devtools.inspectedWindow.tabId,
+  })
+})
+// #endif
+
 port.onMessage.addListener(msg => {
   switch (msg.type) {
     case 'clear': {


### PR DESCRIPTION
On any platform besides Firefox avoid excessive `chrome.tabs.onUpdated`
invocations. This commit does nothing on Firefox because Firefox has
some race conditions. Also, Firefox does not support non-persistent background
contexts so it would not benefit from this optimization.